### PR TITLE
Added call to free on layerInstance.intGridCsv when len != 0

### DIFF
--- a/src/LDtk.zig
+++ b/src/LDtk.zig
@@ -302,6 +302,9 @@ pub const LayerInstance = struct {
             entityInstance.deinit(alloc);
         }
         alloc.free(layerInstance.entityInstances);
+        if (layerInstance.intGridCsv.len != 0) {
+            alloc.free(layerInstance.intGridCsv);
+        }
     }
 };
 


### PR DESCRIPTION
LayerInstance.deinit() doesn't free int grids and only accounts for TileInstances, this fixes that memory leak.